### PR TITLE
Added Probe Volumes to Lighting Explorer

### DIFF
--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
@@ -177,7 +177,7 @@ namespace UnityEditor.Rendering.HighDefinition
 
         protected virtual UnityEngine.Object[] GetProbeVolumes()
         {
-            return UnityEngine.Object.FindObjectsOfType<ProbeVolume>();
+            return Resources.FindObjectsOfTypeAll<ProbeVolume>();
         }
 
         protected virtual LightingExplorerTableColumn[] GetHDLightColumns()

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
@@ -549,41 +549,68 @@ namespace UnityEditor.Rendering.HighDefinition
                 {
                     SerializedProperty drawProbes = prop.FindPropertyRelative("drawProbes");
                     EditorGUI.PropertyField(r, drawProbes, GUIContent.none);
+                }, (lhs, rhs) =>
+                {
+                    return lhs.FindPropertyRelative("drawProbes").boolValue.CompareTo(rhs.FindPropertyRelative("drawProbes").boolValue);
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.DebugColor, "parameters", 75, (r, prop, dep) =>       // 2: Debug Color
                 {
                     SerializedProperty debugColor = prop.FindPropertyRelative("debugColor");
                     EditorGUI.PropertyField(r, debugColor, GUIContent.none);
+                }, (lhs, rhs) =>
+                {
+                    float lh, ls, lv, rh, rs, rv;
+                    Color.RGBToHSV(lhs.FindPropertyRelative("debugColor").colorValue, out lh, out ls, out lv);
+                    Color.RGBToHSV(rhs.FindPropertyRelative("debugColor").colorValue, out rh, out rs, out rv);
+                    return lh.CompareTo(rh);
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.ResolutionX, "parameters", 75, (r, prop, dep) =>      // 3: Resolution X
                 {
                     SerializedProperty resolutionX = prop.FindPropertyRelative("resolutionX");
                     EditorGUI.PropertyField(r, resolutionX, GUIContent.none);
+                }, (lhs, rhs) =>
+                {
+                    return lhs.FindPropertyRelative("resolutionX").intValue.CompareTo(rhs.FindPropertyRelative("resolutionX").intValue);
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.ResolutionY, "parameters", 75, (r, prop, dep) =>      // 4: Resolution Y
                 {
                     SerializedProperty resolutionY = prop.FindPropertyRelative("resolutionY");
                     EditorGUI.PropertyField(r, resolutionY, GUIContent.none);
+                }, (lhs, rhs) =>
+                {
+                    return lhs.FindPropertyRelative("resolutionY").intValue.CompareTo(rhs.FindPropertyRelative("resolutionY").intValue);
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.ResolutionZ, "parameters", 75, (r, prop, dep) =>      // 5: Resolution Z
                 {
                     SerializedProperty resolutionZ = prop.FindPropertyRelative("resolutionZ");
                     EditorGUI.PropertyField(r, resolutionZ, GUIContent.none);
+                }, (lhs, rhs) =>
+                {
+                    return lhs.FindPropertyRelative("resolutionZ").intValue.CompareTo(rhs.FindPropertyRelative("resolutionZ").intValue);
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.BlendDistance, "parameters", 85, (r, prop, dep) =>    // 6: Blend Distance
                 {
                     SerializedProperty uniformFade = prop.FindPropertyRelative("m_UniformFade");
                     EditorGUI.PropertyField(r, uniformFade, GUIContent.none);
+                }, (lhs, rhs) =>
+                {
+                    return lhs.FindPropertyRelative("m_UniformFade").floatValue.CompareTo(rhs.FindPropertyRelative("m_UniformFade").floatValue);
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.FadeStart, "parameters", 60, (r, prop, dep) =>        // 7: Distance Fade Start
                 {
                     SerializedProperty distanceFadeStart = prop.FindPropertyRelative("distanceFadeStart");
                     EditorGUI.PropertyField(r, distanceFadeStart, GUIContent.none);
+                }, (lhs, rhs) =>
+                {
+                    return lhs.FindPropertyRelative("distanceFadeStart").floatValue.CompareTo(rhs.FindPropertyRelative("distanceFadeStart").floatValue);
                 }),
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.FadeEnd, "parameters", 60, (r, prop, dep) =>          // 8: Distance Fade End
                 {
                     SerializedProperty distanceFadeEnd = prop.FindPropertyRelative("distanceFadeEnd");
                     EditorGUI.PropertyField(r, distanceFadeEnd, GUIContent.none);
+                }, (lhs, rhs) =>
+                {
+                    return lhs.FindPropertyRelative("distanceFadeEnd").floatValue.CompareTo(rhs.FindPropertyRelative("distanceFadeEnd").floatValue);
                 })
             };
         }

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
@@ -567,7 +567,15 @@ namespace UnityEditor.Rendering.HighDefinition
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.ResolutionX, "parameters", 75, (r, prop, dep) =>      // 3: Resolution X
                 {
                     SerializedProperty resolutionX = prop.FindPropertyRelative("resolutionX");
+
+                    EditorGUI.BeginChangeCheck();
                     EditorGUI.PropertyField(r, resolutionX, GUIContent.none);
+
+                    if (EditorGUI.EndChangeCheck())
+                    {
+                        ProbeVolumeSystem.ComputeProbeVolumeMaxResolutionFromConstraintX(out int maxX, out int maxY, out int maxZ, resolutionX.intValue);
+                        resolutionX.intValue = Mathf.Clamp(resolutionX.intValue, 1, maxX);
+                    }
                 }, (lhs, rhs) =>
                 {
                     return lhs.FindPropertyRelative("resolutionX").intValue.CompareTo(rhs.FindPropertyRelative("resolutionX").intValue);
@@ -575,7 +583,16 @@ namespace UnityEditor.Rendering.HighDefinition
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.ResolutionY, "parameters", 75, (r, prop, dep) =>      // 4: Resolution Y
                 {
                     SerializedProperty resolutionY = prop.FindPropertyRelative("resolutionY");
+
+                    EditorGUI.BeginChangeCheck();
                     EditorGUI.PropertyField(r, resolutionY, GUIContent.none);
+
+                    if (EditorGUI.EndChangeCheck())
+                    {
+                        SerializedProperty resolutionX = prop.FindPropertyRelative("resolutionX");
+                        ProbeVolumeSystem.ComputeProbeVolumeMaxResolutionFromConstraintX(out int maxX, out int maxY, out int maxZ, resolutionX.intValue);
+                        resolutionY.intValue = Mathf.Clamp(resolutionY.intValue, 1, maxY);
+                    }
                 }, (lhs, rhs) =>
                 {
                     return lhs.FindPropertyRelative("resolutionY").intValue.CompareTo(rhs.FindPropertyRelative("resolutionY").intValue);
@@ -583,7 +600,16 @@ namespace UnityEditor.Rendering.HighDefinition
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.ResolutionZ, "parameters", 75, (r, prop, dep) =>      // 5: Resolution Z
                 {
                     SerializedProperty resolutionZ = prop.FindPropertyRelative("resolutionZ");
+                    
+                    EditorGUI.BeginChangeCheck();
                     EditorGUI.PropertyField(r, resolutionZ, GUIContent.none);
+
+                    if (EditorGUI.EndChangeCheck())
+                    {
+                        SerializedProperty resolutionX = prop.FindPropertyRelative("resolutionX");
+                        ProbeVolumeSystem.ComputeProbeVolumeMaxResolutionFromConstraintX(out int maxX, out int maxY, out int maxZ, resolutionX.intValue);
+                        resolutionZ.intValue = Mathf.Clamp(resolutionZ.intValue, 1, maxZ);
+                    }
                 }, (lhs, rhs) =>
                 {
                     return lhs.FindPropertyRelative("resolutionZ").intValue.CompareTo(rhs.FindPropertyRelative("resolutionZ").intValue);

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
@@ -105,7 +105,6 @@ namespace UnityEditor.Rendering.HighDefinition
             public static readonly GUIContent ResolutionX = EditorGUIUtility.TrTextContent("Resolution X");
             public static readonly GUIContent ResolutionY = EditorGUIUtility.TrTextContent("Resolution Y");
             public static readonly GUIContent ResolutionZ = EditorGUIUtility.TrTextContent("Resolution Z");
-            public static readonly GUIContent BlendDistance = EditorGUIUtility.TrTextContent("Blend Distance");
             public static readonly GUIContent FadeStart = EditorGUIUtility.TrTextContent("Fade Start");
             public static readonly GUIContent FadeEnd = EditorGUIUtility.TrTextContent("Fade End");
 
@@ -614,15 +613,7 @@ namespace UnityEditor.Rendering.HighDefinition
                 {
                     return lhs.FindPropertyRelative("resolutionZ").intValue.CompareTo(rhs.FindPropertyRelative("resolutionZ").intValue);
                 }),
-                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Float, HDStyles.BlendDistance, "parameters", 85, (r, prop, dep) =>    // 6: Blend Distance
-                {
-                    SerializedProperty uniformFade = prop.FindPropertyRelative("m_UniformFade");
-                    EditorGUI.PropertyField(r, uniformFade, GUIContent.none);
-                }, (lhs, rhs) =>
-                {
-                    return lhs.FindPropertyRelative("m_UniformFade").floatValue.CompareTo(rhs.FindPropertyRelative("m_UniformFade").floatValue);
-                }),
-                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Float, HDStyles.FadeStart, "parameters", 65, (r, prop, dep) =>        // 7: Distance Fade Start
+                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Float, HDStyles.FadeStart, "parameters", 65, (r, prop, dep) =>        // 6: Distance Fade Start
                 {
                     SerializedProperty distanceFadeStart = prop.FindPropertyRelative("distanceFadeStart");
                     EditorGUI.PropertyField(r, distanceFadeStart, GUIContent.none);
@@ -630,7 +621,7 @@ namespace UnityEditor.Rendering.HighDefinition
                 {
                     return lhs.FindPropertyRelative("distanceFadeStart").floatValue.CompareTo(rhs.FindPropertyRelative("distanceFadeStart").floatValue);
                 }),
-                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Float, HDStyles.FadeEnd, "parameters", 65, (r, prop, dep) =>          // 8: Distance Fade End
+                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Float, HDStyles.FadeEnd, "parameters", 65, (r, prop, dep) =>          // 7: Distance Fade End
                 {
                     SerializedProperty distanceFadeEnd = prop.FindPropertyRelative("distanceFadeEnd");
                     EditorGUI.PropertyField(r, distanceFadeEnd, GUIContent.none);

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
@@ -545,7 +545,7 @@ namespace UnityEditor.Rendering.HighDefinition
             return new[]
             {
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Name, HDStyles.Name, null, 200),                                       // 0: Name
-                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.DrawProbes, "parameters", 35, (r, prop, dep) =>       // 1: Draw Probes
+                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Checkbox, HDStyles.DrawProbes, "parameters", 35, (r, prop, dep) =>       // 1: Draw Probes
                 {
                     SerializedProperty drawProbes = prop.FindPropertyRelative("drawProbes");
                     EditorGUI.PropertyField(r, drawProbes, GUIContent.none);
@@ -553,7 +553,7 @@ namespace UnityEditor.Rendering.HighDefinition
                 {
                     return lhs.FindPropertyRelative("drawProbes").boolValue.CompareTo(rhs.FindPropertyRelative("drawProbes").boolValue);
                 }),
-                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.DebugColor, "parameters", 75, (r, prop, dep) =>       // 2: Debug Color
+                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Color, HDStyles.DebugColor, "parameters", 75, (r, prop, dep) =>       // 2: Debug Color
                 {
                     SerializedProperty debugColor = prop.FindPropertyRelative("debugColor");
                     EditorGUI.PropertyField(r, debugColor, GUIContent.none);
@@ -564,7 +564,7 @@ namespace UnityEditor.Rendering.HighDefinition
                     Color.RGBToHSV(rhs.FindPropertyRelative("debugColor").colorValue, out rh, out rs, out rv);
                     return lh.CompareTo(rh);
                 }),
-                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.ResolutionX, "parameters", 75, (r, prop, dep) =>      // 3: Resolution X
+                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Int, HDStyles.ResolutionX, "parameters", 75, (r, prop, dep) =>      // 3: Resolution X
                 {
                     SerializedProperty resolutionX = prop.FindPropertyRelative("resolutionX");
 
@@ -580,7 +580,7 @@ namespace UnityEditor.Rendering.HighDefinition
                 {
                     return lhs.FindPropertyRelative("resolutionX").intValue.CompareTo(rhs.FindPropertyRelative("resolutionX").intValue);
                 }),
-                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.ResolutionY, "parameters", 75, (r, prop, dep) =>      // 4: Resolution Y
+                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Int, HDStyles.ResolutionY, "parameters", 75, (r, prop, dep) =>      // 4: Resolution Y
                 {
                     SerializedProperty resolutionY = prop.FindPropertyRelative("resolutionY");
 
@@ -597,7 +597,7 @@ namespace UnityEditor.Rendering.HighDefinition
                 {
                     return lhs.FindPropertyRelative("resolutionY").intValue.CompareTo(rhs.FindPropertyRelative("resolutionY").intValue);
                 }),
-                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.ResolutionZ, "parameters", 75, (r, prop, dep) =>      // 5: Resolution Z
+                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Int, HDStyles.ResolutionZ, "parameters", 75, (r, prop, dep) =>      // 5: Resolution Z
                 {
                     SerializedProperty resolutionZ = prop.FindPropertyRelative("resolutionZ");
                     
@@ -614,7 +614,7 @@ namespace UnityEditor.Rendering.HighDefinition
                 {
                     return lhs.FindPropertyRelative("resolutionZ").intValue.CompareTo(rhs.FindPropertyRelative("resolutionZ").intValue);
                 }),
-                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.BlendDistance, "parameters", 85, (r, prop, dep) =>    // 6: Blend Distance
+                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Float, HDStyles.BlendDistance, "parameters", 85, (r, prop, dep) =>    // 6: Blend Distance
                 {
                     SerializedProperty uniformFade = prop.FindPropertyRelative("m_UniformFade");
                     EditorGUI.PropertyField(r, uniformFade, GUIContent.none);
@@ -622,7 +622,7 @@ namespace UnityEditor.Rendering.HighDefinition
                 {
                     return lhs.FindPropertyRelative("m_UniformFade").floatValue.CompareTo(rhs.FindPropertyRelative("m_UniformFade").floatValue);
                 }),
-                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.FadeStart, "parameters", 60, (r, prop, dep) =>        // 7: Distance Fade Start
+                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Float, HDStyles.FadeStart, "parameters", 65, (r, prop, dep) =>        // 7: Distance Fade Start
                 {
                     SerializedProperty distanceFadeStart = prop.FindPropertyRelative("distanceFadeStart");
                     EditorGUI.PropertyField(r, distanceFadeStart, GUIContent.none);
@@ -630,7 +630,7 @@ namespace UnityEditor.Rendering.HighDefinition
                 {
                     return lhs.FindPropertyRelative("distanceFadeStart").floatValue.CompareTo(rhs.FindPropertyRelative("distanceFadeStart").floatValue);
                 }),
-                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.FadeEnd, "parameters", 60, (r, prop, dep) =>          // 8: Distance Fade End
+                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Float, HDStyles.FadeEnd, "parameters", 65, (r, prop, dep) =>          // 8: Distance Fade End
                 {
                     SerializedProperty distanceFadeEnd = prop.FindPropertyRelative("distanceFadeEnd");
                     EditorGUI.PropertyField(r, distanceFadeEnd, GUIContent.none);

--- a/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
+++ b/com.unity.render-pipelines.high-definition/Editor/Lighting/HDLightExplorerExtension.cs
@@ -100,6 +100,15 @@ namespace UnityEditor.Rendering.HighDefinition
             public static readonly GUIContent ParallaxCorrection = EditorGUIUtility.TrTextContent("Parallax Correction");
             public static readonly GUIContent ReflectionProbeWeight = EditorGUIUtility.TrTextContent("Weight");
 
+            public static readonly GUIContent DrawProbes = EditorGUIUtility.TrTextContent("Draw");
+            public static readonly GUIContent DebugColor = EditorGUIUtility.TrTextContent("Debug Color");
+            public static readonly GUIContent ResolutionX = EditorGUIUtility.TrTextContent("Resolution X");
+            public static readonly GUIContent ResolutionY = EditorGUIUtility.TrTextContent("Resolution Y");
+            public static readonly GUIContent ResolutionZ = EditorGUIUtility.TrTextContent("Resolution Z");
+            public static readonly GUIContent BlendDistance = EditorGUIUtility.TrTextContent("Blend Distance");
+            public static readonly GUIContent FadeStart = EditorGUIUtility.TrTextContent("Fade Start");
+            public static readonly GUIContent FadeEnd = EditorGUIUtility.TrTextContent("Fade End");
+
             public static readonly GUIContent[] LightmapBakeTypeTitles = { EditorGUIUtility.TrTextContent("Realtime"), EditorGUIUtility.TrTextContent("Mixed"), EditorGUIUtility.TrTextContent("Baked") };
             public static readonly int[] LightmapBakeTypeValues = { (int)LightmapBakeType.Realtime, (int)LightmapBakeType.Mixed, (int)LightmapBakeType.Baked };
         }
@@ -112,7 +121,8 @@ namespace UnityEditor.Rendering.HighDefinition
                 new LightingExplorerTab("Volumes", GetVolumes, GetVolumeColumns),
                 new LightingExplorerTab("Reflection Probes", GetHDReflectionProbes, GetHDReflectionProbeColumns),
                 new LightingExplorerTab("Planar Reflection Probes", GetPlanarReflections, GetPlanarReflectionColumns),
-                new LightingExplorerTab("LightProbes", GetLightProbes, GetLightProbeColumns),
+                new LightingExplorerTab("Light Probes", GetLightProbes, GetLightProbeColumns),
+                new LightingExplorerTab("Probe Volumes", GetProbeVolumes, GetProbeVolumeColumns),
                 new LightingExplorerTab("Emissive Materials", GetEmissives, GetEmissivesColumns)
             };
         }
@@ -163,6 +173,11 @@ namespace UnityEditor.Rendering.HighDefinition
                     : new VolumeData(volume.isGlobal, volume.HasInstantiatedProfile() ? volume.profile : volume.sharedProfile, hasStaticLightingSky);
             }
             return volumes;
+        }
+
+        protected virtual UnityEngine.Object[] GetProbeVolumes()
+        {
+            return UnityEngine.Object.FindObjectsOfType<ProbeVolume>();
         }
 
         protected virtual LightingExplorerTableColumn[] GetHDLightColumns()
@@ -522,6 +537,54 @@ namespace UnityEditor.Rendering.HighDefinition
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Name, HDStyles.Name, null, 200),                                               // 0: Name
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Checkbox, HDStyles.On, "m_Enabled", 25),                                       // 1: Enabled
                 new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Float, HDStyles.ReflectionProbeWeight, "m_ProbeSettings.lighting.weight", 50), // 2: Weight
+            };
+        }
+
+        protected virtual LightingExplorerTableColumn[] GetProbeVolumeColumns()
+        {
+            return new[]
+            {
+                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Name, HDStyles.Name, null, 200),                                       // 0: Name
+                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.DrawProbes, "parameters", 35, (r, prop, dep) =>       // 1: Draw Probes
+                {
+                    SerializedProperty drawProbes = prop.FindPropertyRelative("drawProbes");
+                    EditorGUI.PropertyField(r, drawProbes, GUIContent.none);
+                }),
+                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.DebugColor, "parameters", 75, (r, prop, dep) =>       // 2: Debug Color
+                {
+                    SerializedProperty debugColor = prop.FindPropertyRelative("debugColor");
+                    EditorGUI.PropertyField(r, debugColor, GUIContent.none);
+                }),
+                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.ResolutionX, "parameters", 75, (r, prop, dep) =>      // 3: Resolution X
+                {
+                    SerializedProperty resolutionX = prop.FindPropertyRelative("resolutionX");
+                    EditorGUI.PropertyField(r, resolutionX, GUIContent.none);
+                }),
+                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.ResolutionY, "parameters", 75, (r, prop, dep) =>      // 4: Resolution Y
+                {
+                    SerializedProperty resolutionY = prop.FindPropertyRelative("resolutionY");
+                    EditorGUI.PropertyField(r, resolutionY, GUIContent.none);
+                }),
+                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.ResolutionZ, "parameters", 75, (r, prop, dep) =>      // 5: Resolution Z
+                {
+                    SerializedProperty resolutionZ = prop.FindPropertyRelative("resolutionZ");
+                    EditorGUI.PropertyField(r, resolutionZ, GUIContent.none);
+                }),
+                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.BlendDistance, "parameters", 85, (r, prop, dep) =>    // 6: Blend Distance
+                {
+                    SerializedProperty uniformFade = prop.FindPropertyRelative("m_UniformFade");
+                    EditorGUI.PropertyField(r, uniformFade, GUIContent.none);
+                }),
+                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.FadeStart, "parameters", 60, (r, prop, dep) =>        // 7: Distance Fade Start
+                {
+                    SerializedProperty distanceFadeStart = prop.FindPropertyRelative("distanceFadeStart");
+                    EditorGUI.PropertyField(r, distanceFadeStart, GUIContent.none);
+                }),
+                new LightingExplorerTableColumn(LightingExplorerTableColumn.DataType.Custom, HDStyles.FadeEnd, "parameters", 60, (r, prop, dep) =>          // 8: Distance Fade End
+                {
+                    SerializedProperty distanceFadeEnd = prop.FindPropertyRelative("distanceFadeEnd");
+                    EditorGUI.PropertyField(r, distanceFadeEnd, GUIContent.none);
+                })
             };
         }
 

--- a/com.unity.render-pipelines.high-definition/Runtime/Lighting/ProbeVolume/ProbeVolumeSystem.cs
+++ b/com.unity.render-pipelines.high-definition/Runtime/Lighting/ProbeVolume/ProbeVolumeSystem.cs
@@ -109,7 +109,7 @@ namespace UnityEngine.Rendering.HighDefinition
         {
             maxY = s_ProbeVolumeAtlasHeight;
             maxX = s_ProbeVolumeAtlasWidth;
-            maxZ = s_ProbeVolumeAtlasWidth / Mathf.Min(maxX, requestedX);
+            maxZ = s_ProbeVolumeAtlasWidth / Mathf.Clamp(requestedX, 1, maxX);
         }
 
         public void Build(HDRenderPipelineAsset asset)


### PR DESCRIPTION
Added a new Probe Volumes tab with 8 new columns. Please have a look and see if we need any more? The Lighting Explorer doesn't really support vectors and asset fields so well, so I skipped those. I picked the ones I thought would make sense to have as "multi-edit" fields. 

<img width="1211" alt="Screenshot 2019-10-02 at 20 17 29" src="https://user-images.githubusercontent.com/2025561/66070489-b4cdab00-e551-11e9-8aed-12cb89afbf57.png">

